### PR TITLE
Update KnobBoxTesting.cpp ADC pinout

### DIFF
--- a/test/KnobBoxTesting.cpp
+++ b/test/KnobBoxTesting.cpp
@@ -21,12 +21,13 @@ LiquidCrystal_I2C lcd(0x27, 16, 2);
 Timer<3, millis> timer;
 
 // Channel assignment:
-//   A0 -> Voltage Monitor from Bertan 
-//   A1 -> Pot (voltage program setting)
-//   A2 -> Current Monitor from Bertan
-#define CH_VMON      0
-#define CH_POT       1
-#define CH_IMON      2
+//   A0 -> Pot (voltage program setting)
+//   A1 -> Current Monitor from Bertan
+//   A2 -> Voltage Monitor from Bertan 
+// This was changed from the 902b tests
+#define CH_POT       0
+#define CH_IMON      1
+#define CH_VMON      2
 
 //Power supply mode pin define
 #define SET_BERTAN_3KV 48


### PR DESCRIPTION
The Knob Box design overall has a different ADC pinout from the 902b 3kV and 20kV tests, so we are changing the ADC pinout for the Matsusada tests to match the Knob Box.