### PR TITLE
Merge develop to main - 3kV Arc Cycle Enabled, 5s LCD, v2.2

### DIFF
--- a/logic-arduino/logic_arduino.cpp
+++ b/logic-arduino/logic_arduino.cpp
@@ -64,7 +64,7 @@ enum class Timer3kVStateMode : uint8_t {
   ENABLE  = 1
 };
 
-// Set to DISABLE to remove all transitions into STATE_3KV_TIMER.
+// Set to DISABLE to remove all transitions into STATE_3KV_TIMER, or ENABLE to keep transitions.
 static constexpr Timer3kVStateMode TIMER_3KV_STATE_MODE = Timer3kVStateMode::ENABLE;
 
 // ========================= Port mapping =========================

--- a/monitor-arduino/monitor_firmware.cpp
+++ b/monitor-arduino/monitor_firmware.cpp
@@ -38,7 +38,7 @@
 
 // Do Not Edit, edit #define SELECTED_PS_ID above instead
 const uint8_t ps_id = SELECTED_PS_ID;
-const char firmwareVersion[] = "2.0";
+const char firmwareVersion[] = "2.2";
 
 // Capture reset cause and stop any inherited watchdog before normal startup runs.
 // This follows the standard avr-libc early-startup watchdog pattern.
@@ -660,7 +660,7 @@ void setup()
     }
 
     displayStartupInfo();
-    delay(3000);
+    delay(5000);                // Display firmware version info for 5 seconds
 
     Serial.println("Initializing Modbus RTU Server on Serial1...");
     Serial1.begin(9600);


### PR DESCRIPTION
* - Update Version Number to 2.2
- Set 3kV Arc Cycle to DISABLED by default
- Changed LCD Version info display time to 5s

* Clarify comment for firmware version delay()

* Re-enable 3kV Timer State for Melt Metal Experiment after further review

---------